### PR TITLE
Convert protocol to lowercase before comparison

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,6 +368,9 @@ OpenHABConnector.prototype.notifyOpenHabItem = function (openHabItem) {
 
         if(server) {
             // Default protocol
+            if(server.protocol != undefined) {
+                server.protocol = server.protocol.toLowerCase()
+            }
             if (server.protocol == undefined || (server.protocol != "http" && server.protocol != "https")) {
                 server.protocol = "http"
             }


### PR DESCRIPTION
In the current state, if the user enters `HTTPS` (all caps like the documentation states), the module will fail to recognize it since it is comparing against `https` (lowercase) and will override the setting to `http`. If this happens, the user will have to realize what's going on and change it to `https` (lowercase) and then it works as expected.

With this change, the protocol is always converted to lowercase (if it is defined) so there are no issues comparing values.